### PR TITLE
feat: peerDeps, fix Ember rules, expand test patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Shared ESLint, Prettier, and Ember linting configurations for all abofs projects
 npm install --save-dev @abofs/code-conventions
 ```
 
+This package declares its ESLint/Prettier/template-lint dependencies as **peer dependencies**. Your project must install them directly:
+
+```bash
+npm install --save-dev eslint @eslint/js typescript-eslint globals prettier
+# For Ember projects:
+npm install --save-dev eslint-plugin-ember ember-eslint-parser ember-template-lint
+# For projects using QUnit:
+npm install --save-dev eslint-plugin-qunit
+```
+
 ## Usage
 
 ### Prettier

--- a/eslint-ember.config.js
+++ b/eslint-ember.config.js
@@ -82,8 +82,7 @@ const configs = [
       'ember/use-ember-data-rfc-395-imports': 'error', // Use @ember-data/ imports
 
       // --- Template rules (via ember-eslint-parser in gjs/gts) ---
-      'ember/template-no-debugger': 'error',
-      'ember/template-no-log': 'error',
+      'ember/template-indent': 'error',
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,9 +82,14 @@ const configs = [
     }
   },
 
-  // Test files — relaxed rules
+  // Test files — relaxed rules + QUnit
   {
-    files: ['**/test/**/*.js', '**/*-test.js', '**/*.test.js'],
+    files: [
+      '**/test/**/*.{js,ts,gjs,gts}',
+      '**/tests/**/*.{js,ts,gjs,gts}',
+      '**/*-test.{js,ts,gjs,gts}',
+      '**/*.test.{js,ts,gjs,gts}'
+    ],
     rules: {
       'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^(module|test)$' }],
       '@typescript-eslint/no-unused-expressions': 'off'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abofs/code-conventions",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared ESLint, Prettier, and Ember linting configurations for abofs projects",
   "type": "module",
   "exports": {
@@ -30,14 +30,21 @@
   },
   "author": "Stone Costa",
   "license": "Apache-2.0",
-  "dependencies": {
-    "@eslint/js": "^10.0.1",
-    "ember-eslint-parser": "^0.5.13",
-    "ember-template-lint": "^7.9.3",
-    "eslint": "^10.0.0",
-    "eslint-plugin-ember": "^12.7.5",
-    "globals": "^17.3.0",
-    "prettier": "^3.8.1",
-    "typescript-eslint": "^8.56.0"
+  "peerDependencies": {
+    "@eslint/js": "^9.0.0 || ^10.0.0",
+    "ember-eslint-parser": "^0.5.0",
+    "ember-template-lint": "^7.0.0",
+    "eslint": "^9.0.0 || ^10.0.0",
+    "eslint-plugin-ember": "^12.0.0",
+    "eslint-plugin-qunit": "^8.0.0",
+    "globals": "^16.0.0 || ^17.0.0",
+    "prettier": "^3.0.0",
+    "typescript-eslint": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-eslint-parser": { "optional": true },
+    "ember-template-lint": { "optional": true },
+    "eslint-plugin-ember": { "optional": true },
+    "eslint-plugin-qunit": { "optional": true }
   }
 }


### PR DESCRIPTION
## Summary

Sprint 1 learnings from wiring Launchpad to `@abofs/code-conventions`:

- **BREAKING: Move all plugin deps to peerDependencies** — prevents duplicate plugin instances under pnpm strict module isolation (was causing "Cannot redefine plugin" errors in consuming projects)
- **Remove non-existent rules** — `ember/template-no-debugger` and `ember/template-no-log` don't exist in `eslint-plugin-ember@12.x`; replaced with `ember/template-indent`
- **Expand test file patterns** — include `.ts`, `.gjs`, `.gts` extensions and both `test/` and `tests/` directories (Ember uses `tests/`)
- **Add `eslint-plugin-qunit`** as optional peerDependency
- **Bump to 0.3.0**

## Context

Discovered during Launchpad remediation (PR in abofs/Launchpad on `fix/sme-review-blockers`). The convention review identified that Launchpad was not importing the shared package. When wiring it up, these issues surfaced.

## Test plan

- [ ] Verify Launchpad `pnpm lint` still passes after updating to `@abofs/code-conventions@0.3.0`
- [ ] Confirm no "Cannot redefine plugin" errors under pnpm
- [ ] Confirm ember-template-lint rules resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)