### PR TITLE
feat: add husky + lint-staged pre-commit hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,84 @@ What it includes:
 
 ---
 
+## Pre-commit Hooks (husky + lint-staged)
+
+Enforce formatting and linting automatically on every commit. Solves unformatted code reaching the repo.
+
+### Install
+
+```bash
+pnpm add -D husky lint-staged
+```
+
+### Setup
+
+1. **Add a `prepare` script** to your root `package.json`:
+
+```json
+{
+  "scripts": {
+    "prepare": "husky"
+  }
+}
+```
+
+2. **Create `lint-staged.config.js`** at the workspace root:
+
+```js
+import config from '@abofs/code-conventions/lint-staged';
+export default config;
+```
+
+3. **Initialize the hook** (one-time, idempotent):
+
+```bash
+pnpm exec code-conventions-setup
+```
+
+This writes `.husky/pre-commit` with:
+
+```sh
+pnpm lint-staged
+```
+
+4. **Run `pnpm install`** to let the `prepare` script initialize husky:
+
+```bash
+pnpm install
+```
+
+### What the hook enforces
+
+| Files                            | Action                              |
+| -------------------------------- | ----------------------------------- |
+| `*.ts`, `*.gts`, `*.js`, `*.mjs` | `eslint --fix` + `prettier --write` |
+| `*.hbs`                          | `ember-template-lint --fix`         |
+| `*.rs`                           | `cargo fmt --all` (workspace-wide)  |
+| `*.css`                          | `prettier --write`                  |
+
+### Requirements
+
+- For pnpm monorepos: `shamefully-hoist=true` in `.npmrc` so that `eslint`, `prettier`, and `ember-template-lint` are resolvable from the workspace root.
+- `cargo` on `PATH` for Rust formatting.
+- The hook is idempotent — running `pnpm exec code-conventions-setup` again safely overwrites with the same content.
+
+### Project-level overrides
+
+To extend or narrow the shared config:
+
+```js
+// lint-staged.config.js
+import baseConfig from '@abofs/code-conventions/lint-staged';
+
+export default {
+  ...baseConfig,
+  '**/*.graphql': ['prettier --write']
+};
+```
+
+---
+
 ## Ember Polaris Conventions
 
 > Our Ember projects follow the **Polaris** paradigm (Ember v6+). This section documents

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,28 @@
+/**
+ * Shared lint-staged configuration for Ember + Rust (Tauri) projects.
+ *
+ * Usage in consuming project's lint-staged.config.js:
+ *   import config from '@abofs/code-conventions/lint-staged';
+ *   export default config;
+ *
+ * File type handlers:
+ *   *.ts, *.gts, *.js, *.mjs  → eslint --fix + prettier --write
+ *   *.hbs                      → ember-template-lint --fix
+ *   *.rs                       → cargo fmt --all (workspace-wide, once per commit)
+ *   *.css                      → prettier --write
+ *
+ * Requirements:
+ *   - eslint, prettier, ember-template-lint must be resolvable from the workspace root
+ *   - cargo must be on PATH for Rust formatting
+ *   - For pnpm monorepos: shamefully-hoist=true in .npmrc, or link-workspace-packages
+ */
+
+/** @type {import('lint-staged').Config} */
+const config = {
+  '**/*.{ts,gts,js,mjs}': ['eslint --fix', 'prettier --write'],
+  '**/*.hbs': ['ember-template-lint --fix'],
+  '**/*.rs': () => 'cargo fmt --all',
+  '**/*.css': ['prettier --write']
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,13 +7,19 @@
     "./prettier": "./prettier.config.js",
     "./eslint": "./eslint.config.js",
     "./eslint-ember": "./eslint-ember.config.js",
-    "./template-lint": "./template-lint.config.js"
+    "./template-lint": "./template-lint.config.js",
+    "./lint-staged": "./lint-staged.config.js"
+  },
+  "bin": {
+    "code-conventions-setup": "./scripts/setup-husky.js"
   },
   "files": [
     "eslint.config.js",
     "eslint-ember.config.js",
     "template-lint.config.js",
     "prettier.config.js",
+    "lint-staged.config.js",
+    "scripts/setup-husky.js",
     "README.md"
   ],
   "scripts": {
@@ -38,6 +44,8 @@
     "eslint-plugin-ember": "^12.0.0",
     "eslint-plugin-qunit": "^8.0.0",
     "globals": "^16.0.0 || ^17.0.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "typescript-eslint": "^8.0.0"
   },
@@ -52,6 +60,12 @@
       "optional": true
     },
     "eslint-plugin-qunit": {
+      "optional": true
+    },
+    "husky": {
+      "optional": true
+    },
+    "lint-staged": {
       "optional": true
     }
   }

--- a/scripts/setup-husky.js
+++ b/scripts/setup-husky.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Idempotent setup: initializes the husky pre-commit hook in a consuming project.
+ *
+ * Writes .husky/pre-commit configured to run lint-staged. Safe to run multiple
+ * times — always writes the canonical hook content, never accumulates duplicates.
+ *
+ * Usage:
+ *   node node_modules/@abofs/code-conventions/scripts/setup-husky.js
+ *   # or via the bin alias:
+ *   pnpm exec code-conventions-setup
+ */
+
+import { existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+
+const cwd = process.cwd();
+const huskyDir = join(cwd, '.husky');
+const preCommitPath = join(huskyDir, 'pre-commit');
+
+const HOOK_CONTENT = 'pnpm lint-staged\n';
+
+if (!existsSync(huskyDir)) {
+  mkdirSync(huskyDir, { recursive: true });
+}
+
+writeFileSync(preCommitPath, HOOK_CONTENT, 'utf8');
+chmodSync(preCommitPath, 0o755);
+
+console.log('✓ Wrote .husky/pre-commit');
+console.log('');
+console.log('Next steps (if not already done):');
+console.log('  1. Add to your root package.json scripts: "prepare": "husky"');
+console.log('  2. Add a lint-staged.config.js that imports from @abofs/code-conventions/lint-staged');
+console.log('  3. Run pnpm install to initialize husky via the prepare script');


### PR DESCRIPTION
## Summary

- Add `lint-staged.config.js` exporting a shared config for Ember + Rust (Tauri) monorepos
- Add `scripts/setup-husky.js` — idempotent bin script that writes `.husky/pre-commit`
- Register bin alias `code-conventions-setup` in `package.json`
- Add `husky` and `lint-staged` as optional peer dependencies
- Update `exports` map and `files` array to include new assets
- Document the full setup flow in README

### What the hook enforces

| Files | Action |
|-------|--------|
| `*.ts`, `*.gts`, `*.js`, `*.mjs` | `eslint --fix` + `prettier --write` |
| `*.hbs` | `ember-template-lint --fix` |
| `*.rs` | `cargo fmt --all` (workspace-wide) |
| `*.css` | `prettier --write` |

### Why

Agents were shipping unformatted code. This gives every consuming project a one-command setup that enforces formatting/linting on every commit, without requiring changes to the project's own tooling config.

## Test plan

- [ ] `pnpm lint` passes on code-conventions itself
- [ ] Consuming project: `pnpm exec code-conventions-setup` writes `.husky/pre-commit`
- [ ] `pnpm install` in consuming project runs `husky` via `prepare` script
- [ ] Pre-commit hook runs `pnpm lint-staged` and catches unformatted files
- [ ] Re-running setup is idempotent (safe to call multiple times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)