### PR TITLE
fix: disable ember/template-indent (crashes on .gts with ESLint 9.x)

### DIFF
--- a/eslint-ember.config.js
+++ b/eslint-ember.config.js
@@ -82,7 +82,13 @@ const configs = [
       'ember/use-ember-data-rfc-395-imports': 'error', // Use @ember-data/ imports
 
       // --- Template rules (via ember-eslint-parser in gjs/gts) ---
-      'ember/template-indent': 'error'
+      // DISABLED: ember/template-indent crashes on .gts files with valueless
+      // HTML attributes (e.g. data-test-*). The rule wraps ESLint's core
+      // indent rule which throws "Cannot read properties of null (reading
+      // 'range')" on JSXAttribute nodes without values. No upstream fix
+      // available (12.7.5 is latest). Re-enable when patched.
+      // Tracking: eslint-plugin-ember + ESLint 9.x indent rule interaction
+      'ember/template-indent': 'off'
     }
   },
 


### PR DESCRIPTION
## Problem

`ember/template-indent` crashes on `.gts` files with valueless HTML attributes (e.g. `data-test-*`):

```
TypeError: Cannot read properties of null (reading 'range')
Rule: "ember/template-indent"
    at JSXAttribute[value] (eslint/lib/rules/indent.js:2015:19)
```

### Root Cause

The rule wraps ESLint's core `indent` rule and creates synthetic JSXAttribute nodes from Glimmer element attributes. Valueless HTML attributes have `value: null`, but the core indent rule's `JSXAttribute[value]` handler assumes `value` always exists.

### Research

- `eslint-plugin-ember@12.7.5` is the latest published version (12.7.6 exists in changelog but isn't on npm)
- The rule is `recommendedGts: false` — we explicitly enabled it
- No upstream fix available
- Affects ESLint 9.x + eslint-plugin-ember 12.x

## Fix

Changed `ember/template-indent` from `'error'` to `'off'` in the shared Ember config with a detailed comment explaining why and when to re-enable.

This is the correct place for the fix (single source of truth) rather than every consuming project adding overrides.