### PR TITLE
chore: onboarding setup — docs, LICENSE, security hardening

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,15 @@
+# Code Conventions
+
+Shared ESLint, Prettier, and Ember linting configurations for all abofs projects. Published to npm as `@abofs/code-conventions`.
+
+## Documentation
+
+See [`docs/index.md`](../docs/index.md) for the full documentation index.
+
+## Quick Reference
+
+- **Package:** `@abofs/code-conventions`
+- **Exports:** `./eslint`, `./eslint-ember`, `./prettier`, `./template-lint`, `./lint-staged`
+- **CLI:** `code-conventions-setup` (husky pre-commit setup)
+- **Test:** `pnpm test` (eslint + prettier self-check)
+- **Release:** `docs/release.md`

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.env
+.npmrc

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+.git/
+.github/
+.claude/
+docs/
+node_modules/
+pnpm-lock.yaml
+.prettierignore
+.gitignore
+.npmignore
+.env
+.npmrc
+test/
+scripts/
+*.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Stone Costa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# Code Conventions Documentation
+
+`@abofs/code-conventions` — shared ESLint, Prettier, and Ember linting configurations for all abofs projects.
+
+## Key Files
+
+| File                          | Purpose                                            |
+| ----------------------------- | -------------------------------------------------- |
+| [README.md](../README.md)     | Installation, usage, and full code style reference |
+| [docs/release.md](release.md) | Release process (npm publish)                      |
+
+## Config Modules
+
+| Export            | File                      | Description                             |
+| ----------------- | ------------------------- | --------------------------------------- |
+| `./eslint`        | `eslint.config.js`        | Base ESLint flat config (JS/TS)         |
+| `./eslint-ember`  | `eslint-ember.config.js`  | Ember Polaris ESLint config             |
+| `./prettier`      | `prettier.config.js`      | Shared Prettier config                  |
+| `./template-lint` | `template-lint.config.js` | Shared ember-template-lint config       |
+| `./lint-staged`   | `lint-staged.config.js`   | lint-staged config (JS/TS/HBS/Rust/CSS) |
+
+## CLI
+
+| Command                  | Description                            |
+| ------------------------ | -------------------------------------- |
+| `code-conventions-setup` | Idempotent husky pre-commit hook setup |

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,35 @@
+# Release Process
+
+`@abofs/code-conventions` is published to npm via GitHub Actions using the shared `abofs/stonyx-workflows` reusable workflow.
+
+## Publishing
+
+### Automated (push to main)
+
+Pushing to `main` triggers the publish workflow which auto-publishes a prerelease version.
+
+### Manual Release
+
+1. Go to **Actions** → **Publish** → **Run workflow**
+2. Select version type: `patch`, `minor`, or `major` (or enter a custom version)
+3. The workflow bumps `package.json`, publishes to npm with provenance, and creates a git tag
+
+### Pre-publish Checklist
+
+- [ ] `pnpm test` passes (eslint + prettier self-check)
+- [ ] `npm pack --dry-run` shows only intended files
+- [ ] `npm audit` has no new high/critical vulnerabilities in peer deps
+- [ ] Consuming projects tested with the new version
+
+## Versioning
+
+- Follows semver
+- Breaking changes to config rules = major bump
+- New rule additions = minor bump
+- Rule config tweaks / bug fixes = patch bump
+
+## npm
+
+- Package: `@abofs/code-conventions`
+- Registry: https://www.npmjs.com/package/@abofs/code-conventions
+- Provenance: enabled (`publishConfig.provenance: true`)

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -19,7 +19,7 @@
 
 /** @type {import('lint-staged').Config} */
 const config = {
-  '**/*.{ts,gts,js,mjs}': ['eslint --fix', 'prettier --write'],
+  '**/*.{ts,gts,gjs,js,mjs}': ['eslint --fix', 'prettier --write'],
   '**/*.hbs': ['ember-template-lint --fix'],
   '**/*.rs': () => 'cargo fmt --all',
   '**/*.css': ['prettier --write']


### PR DESCRIPTION
## Summary

- Add `docs/index.md` and `docs/release.md` per framework doc convention
- Add `.claude/CLAUDE.md` entry point for agent context
- Add Apache-2.0 `LICENSE` file (declared in package.json but was missing)
- Add `.npmignore` as defense-in-depth backup for the `files` whitelist
- Add `.env` and `.npmrc` to `.gitignore` (defensive entries)
- Add `.gjs` to lint-staged ESLint glob (was missing from the pattern)

## Test plan

- [x] `pnpm test` passes (eslint + prettier self-check)
- [x] `npm pack --dry-run` still shows only intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)