### PR TITLE
feat: add project-level SME templates for code-conventions

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -1,0 +1,56 @@
+# SME Template: Architect — Code Conventions
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/architect.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/code-conventions`
+**Package:** `@abofs/code-conventions` (npm, public, scoped)
+**Purpose:** Shared ESLint, Prettier, ember-template-lint, and lint-staged configurations consumed by all abofs projects
+**Version:** `0.3.1-beta.0` (pre-1.0 — API may still evolve)
+
+This is an infrastructure package. Every rule change propagates to every consuming project. Treat changes with the same gravity as a framework API change.
+
+## Package Structure
+
+| File | Export Path | Purpose |
+|------|-------------|---------|
+| `eslint.config.js` | `@abofs/code-conventions/eslint` | ESLint flat config (JS + TS) |
+| `eslint-ember.config.js` | `@abofs/code-conventions/eslint-ember` | Ember/Glimmer ESLint rules (Polaris patterns) |
+| `prettier.config.js` | `@abofs/code-conventions/prettier` | Prettier formatting config |
+| `template-lint.config.js` | `@abofs/code-conventions/template-lint` | ember-template-lint config |
+| `lint-staged.config.js` | `@abofs/code-conventions/lint-staged` | Pre-commit lint-staged config |
+| `scripts/setup-husky.js` | `code-conventions-setup` (bin) | Idempotent husky pre-commit hook setup |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Module system | ESM (`"type": "module"`) |
+| ESLint | v9/v10 flat config (`eslint.config.js` arrays) |
+| TypeScript linting | `typescript-eslint` v8 (peer dep) |
+| Ember linting | `eslint-plugin-ember` v12 + `ember-eslint-parser` (optional peers) |
+| Template linting | `ember-template-lint` v7 (optional peer) |
+| Formatting | Prettier v3 |
+| Git hooks | Husky v9 + lint-staged v15 (optional peers) |
+| Package manager | pnpm |
+
+## Key Patterns
+
+- **Flat config only** — no `.eslintrc.*` legacy format. Consumers spread the exported array: `export default [...configs]`.
+- **Layered Ember config** — `eslint-ember` goes first, then `eslint` base, so base rules win on overlap. Order matters.
+- **Peer dependencies** — core tools (eslint, prettier, globals) are required peers; Ember-specific tools are optional peers. This keeps non-Ember projects from needing Ember dependencies.
+- **Explicit `files` field** — `package.json` enumerates exactly which files ship to npm. This is a security boundary (see Security Reviewer template).
+- **Provenance** — `publishConfig.provenance: true` enables npm provenance attestation on publish.
+- **No runtime dependencies** — zero `dependencies`. Everything is a peer or dev dependency.
+- **WarpDrive enforcement** — the Ember config bans `fetch()` globally and restricts `ember-data` imports, pushing consumers toward WarpDrive patterns.
+- **Test file relaxation** — test files get relaxed rules (unused vars for `module`/`test`, controllers allowed in tests).
+
+## Live Knowledge
+
+- Consuming projects pin a version range (e.g., `^0.3.0`). A new rule set to `error` is a breaking change for any project that currently violates it — coordinate via a version bump and migration notes.
+- The `ember/template-indent` rule is intentionally disabled due to a crash with valueless HTML attributes in `.gts` files. Do not re-enable until upstream fixes land.
+- `no-restricted-globals` banning `fetch` only applies to Ember config consumers. Node.js backend projects use the base `eslint` config, which does not restrict `fetch`.
+- The `setup-husky.js` script writes `.husky/pre-commit` idempotently. It ships as a bin (`code-conventions-setup`) so consumers can run it via `pnpm exec`.
+- Prettier settings: 120 char width, single quotes, no trailing commas, LF line endings, no semicolons in arrow parens.

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,53 @@
+# SME Template: QA/Test Engineer — Code Conventions
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/code-conventions`
+**Package:** `@abofs/code-conventions` (npm, public, scoped)
+**Purpose:** Shared lint and format configurations for all abofs projects
+
+This package has no application logic. "Testing" means verifying that lint rules and config exports behave correctly and do not break consuming projects.
+
+## Test Infrastructure
+
+| What | How |
+|------|-----|
+| Self-lint | `pnpm test` runs `eslint . && prettier --check .` against the package's own source |
+| No unit test framework | There is no QUnit/Jest/Vitest — the package validates itself by linting its own config files |
+| CI | GitHub Actions workflows in `.github/workflows/` |
+
+## Key Patterns
+
+### Rule Correctness
+
+- **No false positives** — a new or changed rule must not flag code that is intentionally allowed across abofs projects. Before promoting a rule to `error`, verify it passes against representative code from consuming projects.
+- **No false negatives** — a rule meant to catch a pattern must actually catch it. Write sample violating code and confirm the rule fires.
+- **Test file relaxations** — rules may be relaxed for test files (`**/test/**`, `**/tests/**`, `**/*-test.*`). Verify that test-specific overrides only apply to test globs, not production code.
+
+### Config Export Verification
+
+- **Named exports** — each config is exported via `package.json` `exports` map (e.g., `@abofs/code-conventions/eslint`). Verify that imports resolve correctly in a consuming project context.
+- **Flat config array shape** — ESLint configs export arrays of config objects. Confirm the array can be spread into a consumer's `eslint.config.js` without errors.
+- **Prettier config shape** — the Prettier export must be a plain object (not an array, not a function). Consumers reference it via `"prettier": "@abofs/code-conventions/prettier"` in `package.json`.
+- **Template-lint config shape** — must be a plain object with `extends` and `rules` keys that can be spread.
+
+### Compatibility Checks
+
+- **Peer dependency ranges** — verify the config works with both the minimum and maximum versions of peer dependencies (e.g., ESLint 9 and ESLint 10, globals 16 and 17).
+- **Optional peer absence** — when optional peers (ember-eslint-parser, eslint-plugin-ember, etc.) are not installed, the base `eslint` and `prettier` configs must still load without errors.
+- **Layered config ordering** — for Ember projects, `eslint-ember` must come before `eslint` base. Verify that reversing the order causes incorrect rule precedence.
+
+### Regression Scenarios
+
+- **WarpDrive restrictions** — `no-restricted-globals` (fetch) and `no-restricted-imports` (ember-data) must fire in Ember config but not in base config.
+- **TypeScript override** — `@typescript-eslint/no-unused-vars` must be active for `.ts` files but disabled for `.js` files (where base `no-unused-vars` applies instead).
+- **Ignored paths** — `node_modules/`, `dist/`, `coverage/`, `declarations/`, `blueprints/` must all be ignored and not produce lint errors.
+
+## Live Knowledge
+
+- The `ember/template-indent` rule is disabled due to an upstream crash. If someone re-enables it, the config will break on `.gts` files with valueless HTML attributes (e.g., `data-test-*`). This is a known regression test case.
+- `no-empty` allows empty catch blocks (`allowEmptyCatch: true`). This is intentional — do not flag it as a gap.
+- The package lints itself with its own config (`eslint.config.js` in the repo root). Any rule change that violates the package's own code will cause `pnpm test` to fail, which serves as a built-in smoke test.

--- a/docs/agents/security-reviewer.md
+++ b/docs/agents/security-reviewer.md
@@ -1,0 +1,55 @@
+# SME Template: Security Reviewer — Code Conventions
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/security-reviewer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/code-conventions`
+**Package:** `@abofs/code-conventions` (npm, public, scoped)
+**Purpose:** Shared lint and format configurations published to npm
+
+This is a publicly published npm package. Security review focuses on what gets published, dependency supply chain, and ensuring the package does not leak sensitive files.
+
+## Key Patterns
+
+### npm Publish Security
+
+- **Explicit `files` allowlist** — `package.json` uses a `files` array to enumerate exactly which files are included in the published tarball. This is the primary security boundary.
+- **Current allowlist:** `eslint.config.js`, `eslint-ember.config.js`, `template-lint.config.js`, `prettier.config.js`, `lint-staged.config.js`, `scripts/setup-husky.js`, `README.md`
+- **`.npmignore` as defense-in-depth** — excludes `.git/`, `.github/`, `.claude/`, `docs/`, `node_modules/`, `pnpm-lock.yaml`, `test/`, `scripts/` (beyond what `files` includes), and log files.
+- **Both gates must agree** — if `files` is present, npm uses it as the allowlist. `.npmignore` provides a second layer in case `files` is accidentally removed or set to a wildcard.
+
+### Past Incident: `files: ["*"]` Leak
+
+A previous abofs package (`stonyx-cron`) shipped with `files: ["*"]` in `package.json`, which caused `.git/` directory contents (including full commit history) to be published to npm. This is the canonical cautionary tale for this project:
+
+- **Never use `files: ["*"]`** or any glob that could match dotfiles/directories.
+- **Never remove the `files` field** — falling back to `.npmignore`-only is less safe.
+- **Review every PR that modifies `package.json`** for changes to the `files` array.
+- **Run `npm pack --dry-run`** before any publish to verify the tarball contents.
+
+### No Secrets in Published Package
+
+- `.env` and `.npmrc` are in `.gitignore` — they should never reach the repo, let alone npm.
+- `docs/`, `.claude/`, and `.github/` are excluded from the publish via both `files` allowlist and `.npmignore`.
+- Config files contain no secrets — they are pure rule definitions with no tokens, keys, or credentials.
+
+### Dependency Supply Chain
+
+- **Zero runtime dependencies** — the package has no `dependencies` field. All tooling is specified as `peerDependencies` (required or optional), meaning the consuming project controls the exact versions installed.
+- **Minimal dev dependencies** — only `@eslint/js`, `eslint`, `globals`, `prettier`, and `typescript-eslint` for self-linting.
+- **Provenance attestation** — `publishConfig.provenance: true` enables npm provenance, linking published versions to their source commit and CI workflow. Verify this remains enabled.
+- **Lock file** — `pnpm-lock.yaml` pins dev dependency versions but is excluded from the published package.
+
+### Publish Configuration
+
+- **Public access** — `publishConfig.access: "public"` (correct for a scoped package that should be publicly available).
+- **Provenance** — `publishConfig.provenance: true` (requires publishing from a CI environment with OIDC support).
+- **No `prepublishOnly` script** — there is no build step. The published files are the source files. This simplifies the supply chain but means any code in the published files runs as-is in consuming projects.
+
+## Live Knowledge
+
+- The `setup-husky.js` script writes files to the consuming project's filesystem (`writeFileSync`, `mkdirSync`, `chmodSync`). It is a bin entry point (`code-conventions-setup`). Review any changes to this script carefully — it executes in the consumer's repo with the consumer's permissions.
+- The `scripts/` directory is listed in `.npmignore` but `scripts/setup-husky.js` is explicitly included via the `files` allowlist. This is intentional — the bin script must ship, but other potential future scripts in that directory should not.
+- Apache-2.0 license. Verify the `LICENSE` file stays in sync with the `license` field in `package.json`.


### PR DESCRIPTION
## Summary

- Add `docs/agents/architect.md` — package structure, tech stack, flat config patterns, versioning considerations
- Add `docs/agents/qa-test-engineer.md` — rule correctness testing, config export verification, peer dependency compatibility checks
- Add `docs/agents/security-reviewer.md` — npm publish security (`files` allowlist), past `files: ["*"]` incident context, dependency supply chain, `setup-husky.js` filesystem write review

All three templates inherit from their base templates in `beatrix-shared/docs/framework/templates/agents/`.

## Test plan

- [ ] Verify each template starts with the required header and inheritance line
- [ ] Confirm content is accurate against current `package.json` exports and config files
- [ ] Check that `docs/agents/` is excluded from npm publish via `.npmignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)